### PR TITLE
feat: add trigger_deploy MCP tool (closes #11)

### DIFF
--- a/pkg/deploy/repo.go
+++ b/pkg/deploy/repo.go
@@ -50,3 +50,26 @@ func (r *Repo) GetDeploy(ctx context.Context, serviceId string, deployId string)
 
 	return resp.JSON200, nil
 }
+func (r *Repo) TriggerDeploy(ctx context.Context, serviceId string, clearCache bool) (*client.Deploy, error) {
+    var clearCacheVal *client.CreateDeployJSONBodyClearCache
+    if clearCache {
+        v := client.Clear
+        clearCacheVal = &v
+    } else {
+        v := client.DoNotClear
+        clearCacheVal = &v
+    }
+
+    body := client.CreateDeployJSONRequestBody{
+        ClearCache: clearCacheVal,
+    }
+
+    resp, err := r.client.CreateDeployWithResponse(ctx, client.ServiceIdParam(serviceId), body)
+    if err != nil {
+        return nil, err
+    }
+    if err := client.ErrorFromResponse(resp); err != nil {
+        return nil, err
+    }
+    return resp.JSON201, nil
+}

--- a/pkg/deploy/tools.go
+++ b/pkg/deploy/tools.go
@@ -17,6 +17,7 @@ func Tools(c *client.ClientWithResponses) []server.ServerTool {
 	return []server.ServerTool{
 		listDeploys(deployRepo),
 		getDeploy(deployRepo),
+		triggerDeploy(deployRepo),
 	}
 }
 
@@ -126,6 +127,50 @@ func getDeploy(deployRepo *Repo) server.ServerTool {
 			}
 
 			respJSON, err := json.Marshal(response)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			return mcp.NewToolResultText(string(respJSON)), nil
+		},
+	}
+}
+func triggerDeploy(deployRepo *Repo) server.ServerTool {
+	return server.ServerTool{
+		Tool: mcp.NewTool("trigger_deploy",
+			mcp.WithDescription("Trigger a new deploy for a service. Use this to redeploy a service after making changes."),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:          "Trigger deploy",
+				ReadOnlyHint:   pointers.From(false),
+				IdempotentHint: pointers.From(false),
+				OpenWorldHint:  pointers.From(true),
+			}),
+			mcp.WithString("serviceId",
+				mcp.Required(),
+				mcp.Description("The ID of the service to trigger a deploy for"),
+			),
+			mcp.WithBoolean("clearCache",
+				mcp.Description("Whether to clear the build cache before deploying. Defaults to false."),
+				mcp.DefaultBool(false),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			serviceId, err := validate.RequiredToolParam[string](request, "serviceId")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			clearCache, _, err := validate.OptionalToolParam[bool](request, "clearCache")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			deploy, err := deployRepo.TriggerDeploy(ctx, serviceId, clearCache)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			respJSON, err := json.Marshal(deploy)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}


### PR DESCRIPTION
Closes #11
Adds a `trigger_deploy` MCP tool that allows triggering a new deploy for a Render service directly from the MCP server.

Why - This was the only missing deploy operation: `list_deploys` and `get_deploy` existed but there was no way to actually trigger one. This has been an open issue since January 7.

How
- Added `TriggerDeploy` to `pkg/deploy/repo.go` using the existing `CreateDeployWithResponse` client method
- Added `trigger_deploy` tool to `pkg/deploy/tools.go` with `serviceId` (required) and `clearCache` (optional, defaults to false) parameters

Testing - Verified end-to-end: triggered a real deploy via Cursor MCP chat, received a valid deploy ID back with status `queued`.