### PR TITLE
Allow updating service compute plan via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ feature requests, bug reports, suggestions, comments, or concerns.
   - `serviceId`: The ID of the service to update (string, required)
   - `envVars`: Complete list of environment variables (array, required)
 
+- **update_web_service** - Update the compute plan of an existing web service. The change is applied immediately and does not require a manual deploy.
+  - `serviceId`: The ID of the web service to update (string, required)
+  - `plan`: The new plan for your web service (string, required). Accepted values:
+    - `free`
+    - `starter`
+    - `standard`
+    - `pro`
+    - `pro_max`
+    - `pro_plus`
+    - `pro_ultra`
+
+- **update_cron_job** - Update the compute plan of an existing cron job. The change is applied immediately and does not require a manual deploy.
+  - `serviceId`: The ID of the cron job to update (string, required)
+  - `plan`: The new plan for your cron job (string, required). Accepted values:
+    - `free`
+    - `starter`
+    - `standard`
+    - `pro`
+    - `pro_max`
+    - `pro_plus`
+    - `pro_ultra`
+
 ### Deployments
 
 - **list_deploys** - List deployment history for a service

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ feature requests, bug reports, suggestions, comments, or concerns.
   - `serviceId`: The ID of the service to update (string, required)
   - `envVars`: Complete list of environment variables (array, required)
 
-- **update_web_service** - Update the compute plan of an existing web service. The change is applied immediately and does not require a manual deploy.
+- **update_web_service** - Update the compute plan of an existing web service. Triggers a new deploy to apply the new instance type (zero-downtime for stateless services; brief downtime for services with an attached persistent disk), so no manual deploy is needed.
   - `serviceId`: The ID of the web service to update (string, required)
   - `plan`: The new plan for your web service (string, required). Accepted values:
     - `free`
@@ -145,7 +145,7 @@ feature requests, bug reports, suggestions, comments, or concerns.
     - `pro_plus`
     - `pro_ultra`
 
-- **update_cron_job** - Update the compute plan of an existing cron job. The change is applied immediately and does not require a manual deploy.
+- **update_cron_job** - Update the compute plan of an existing cron job. Triggers a new deploy to apply the new instance type (takes effect on the next run), so no manual deploy is needed.
   - `serviceId`: The ID of the cron job to update (string, required)
   - `plan`: The new plan for your cron job (string, required). Accepted values:
     - `free`

--- a/pkg/fakes/fakeservicerepoclient_gen.go
+++ b/pkg/fakes/fakeservicerepoclient_gen.go
@@ -102,6 +102,22 @@ type FakeServiceRepoClient struct {
 		result1 *client.UpdateEnvVarsForServiceResponse
 		result2 error
 	}
+	UpdateServiceWithResponseStub        func(context.Context, client.ServiceIdParam, client.UpdateServiceJSONRequestBody, ...client.RequestEditorFn) (*client.UpdateServiceResponse, error)
+	updateServiceWithResponseMutex       sync.RWMutex
+	updateServiceWithResponseArgsForCall []struct {
+		arg1 context.Context
+		arg2 client.ServiceIdParam
+		arg3 client.UpdateServiceJSONRequestBody
+		arg4 []client.RequestEditorFn
+	}
+	updateServiceWithResponseReturns struct {
+		result1 *client.UpdateServiceResponse
+		result2 error
+	}
+	updateServiceWithResponseReturnsOnCall map[int]struct {
+		result1 *client.UpdateServiceResponse
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -510,6 +526,73 @@ func (fake *FakeServiceRepoClient) UpdateEnvVarsForServiceWithResponseReturnsOnC
 	}{result1, result2}
 }
 
+func (fake *FakeServiceRepoClient) UpdateServiceWithResponse(arg1 context.Context, arg2 client.ServiceIdParam, arg3 client.UpdateServiceJSONRequestBody, arg4 ...client.RequestEditorFn) (*client.UpdateServiceResponse, error) {
+	fake.updateServiceWithResponseMutex.Lock()
+	ret, specificReturn := fake.updateServiceWithResponseReturnsOnCall[len(fake.updateServiceWithResponseArgsForCall)]
+	fake.updateServiceWithResponseArgsForCall = append(fake.updateServiceWithResponseArgsForCall, struct {
+		arg1 context.Context
+		arg2 client.ServiceIdParam
+		arg3 client.UpdateServiceJSONRequestBody
+		arg4 []client.RequestEditorFn
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateServiceWithResponseStub
+	fakeReturns := fake.updateServiceWithResponseReturns
+	fake.recordInvocation("UpdateServiceWithResponse", []interface{}{arg1, arg2, arg3, arg4})
+	fake.updateServiceWithResponseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeServiceRepoClient) UpdateServiceWithResponseCallCount() int {
+	fake.updateServiceWithResponseMutex.RLock()
+	defer fake.updateServiceWithResponseMutex.RUnlock()
+	return len(fake.updateServiceWithResponseArgsForCall)
+}
+
+func (fake *FakeServiceRepoClient) UpdateServiceWithResponseCalls(stub func(context.Context, client.ServiceIdParam, client.UpdateServiceJSONRequestBody, ...client.RequestEditorFn) (*client.UpdateServiceResponse, error)) {
+	fake.updateServiceWithResponseMutex.Lock()
+	defer fake.updateServiceWithResponseMutex.Unlock()
+	fake.UpdateServiceWithResponseStub = stub
+}
+
+func (fake *FakeServiceRepoClient) UpdateServiceWithResponseArgsForCall(i int) (context.Context, client.ServiceIdParam, client.UpdateServiceJSONRequestBody, []client.RequestEditorFn) {
+	fake.updateServiceWithResponseMutex.RLock()
+	defer fake.updateServiceWithResponseMutex.RUnlock()
+	argsForCall := fake.updateServiceWithResponseArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeServiceRepoClient) UpdateServiceWithResponseReturns(result1 *client.UpdateServiceResponse, result2 error) {
+	fake.updateServiceWithResponseMutex.Lock()
+	defer fake.updateServiceWithResponseMutex.Unlock()
+	fake.UpdateServiceWithResponseStub = nil
+	fake.updateServiceWithResponseReturns = struct {
+		result1 *client.UpdateServiceResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeServiceRepoClient) UpdateServiceWithResponseReturnsOnCall(i int, result1 *client.UpdateServiceResponse, result2 error) {
+	fake.updateServiceWithResponseMutex.Lock()
+	defer fake.updateServiceWithResponseMutex.Unlock()
+	fake.UpdateServiceWithResponseStub = nil
+	if fake.updateServiceWithResponseReturnsOnCall == nil {
+		fake.updateServiceWithResponseReturnsOnCall = make(map[int]struct {
+			result1 *client.UpdateServiceResponse
+			result2 error
+		})
+	}
+	fake.updateServiceWithResponseReturnsOnCall[i] = struct {
+		result1 *client.UpdateServiceResponse
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeServiceRepoClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -525,6 +608,8 @@ func (fake *FakeServiceRepoClient) Invocations() map[string][][]interface{} {
 	defer fake.retrieveServiceWithResponseMutex.RUnlock()
 	fake.updateEnvVarsForServiceWithResponseMutex.RLock()
 	defer fake.updateEnvVarsForServiceWithResponseMutex.RUnlock()
+	fake.updateServiceWithResponseMutex.RLock()
+	defer fake.updateServiceWithResponseMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/service/repo.go
+++ b/pkg/service/repo.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/render-oss/render-mcp-server/pkg/client"
 	"github.com/render-oss/render-mcp-server/pkg/pointers"
@@ -17,6 +18,7 @@ type serviceRepoClient interface {
 	CreateDeployWithResponse(ctx context.Context, serviceId string, body client.CreateDeployJSONRequestBody, reqEditors ...client.RequestEditorFn) (*client.CreateDeployResponse, error)
 	CreateServiceWithResponse(ctx context.Context, data client.CreateServiceJSONRequestBody, reqEditors ...client.RequestEditorFn) (*client.CreateServiceResponse, error)
 	RetrieveServiceWithResponse(ctx context.Context, id string, reqEditors ...client.RequestEditorFn) (*client.RetrieveServiceResponse, error)
+	UpdateServiceWithResponse(ctx context.Context, serviceId client.ServiceIdParam, body client.UpdateServiceJSONRequestBody, reqEditors ...client.RequestEditorFn) (*client.UpdateServiceResponse, error)
 }
 
 type Repo struct {
@@ -151,6 +153,32 @@ func (s *Repo) CreateService(ctx context.Context, data client.CreateServiceJSONR
 	}
 
 	return resp.JSON201, nil
+}
+
+// UpdateService applies a PATCH to an existing service. It first retrieves the
+// service to confirm it belongs to the selected workspace and that its type
+// matches the caller's expectation, so a tool scoped to one service type (e.g.
+// web service) can't mutate a service of a different type.
+func (s *Repo) UpdateService(ctx context.Context, serviceId string, expectedType client.ServiceType, body client.UpdateServiceJSONRequestBody) (*client.Service, error) {
+	existing, err := s.GetService(ctx, serviceId)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing.Type != expectedType {
+		return nil, fmt.Errorf("service %s is a %s, not a %s; use the matching update tool for that service type", serviceId, existing.Type, expectedType)
+	}
+
+	resp, err := s.client.UpdateServiceWithResponse(ctx, serviceId, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.ErrorFromResponse(resp); err != nil {
+		return nil, err
+	}
+
+	return resp.JSON200, nil
 }
 
 func (s *Repo) GetService(ctx context.Context, id string) (*client.Service, error) {

--- a/pkg/service/tools.go
+++ b/pkg/service/tools.go
@@ -593,8 +593,9 @@ func updateWebService(serviceRepo *Repo) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("update_web_service",
 			mcp.WithDescription("Update the compute plan (instance type) of an existing web service in your Render account. "+
-				"Changing the plan scales the service's CPU and memory. Render applies the change immediately, "+
-				"so a manual deploy is not required. "+
+				"Changing the plan scales the service's CPU and memory. This triggers a new deploy to apply the new "+
+				"instance type, so no manual deploy is needed. The deploy is zero-downtime for stateless services; "+
+				"services with an attached persistent disk briefly go down during the switch. "+
 				"This tool currently only supports changing the plan. For other configuration changes, "+
 				"use the dashboard at: "+config.DashboardURL()+"/web/new"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
@@ -640,12 +641,26 @@ func updateWebService(serviceRepo *Repo) server.ServerTool {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
+			// The Render API records the new plan but does not apply it until the next
+			// successful deploy, so trigger one. This is zero-downtime for stateless
+			// services; services with an attached persistent disk briefly go down.
+			deployResponse, err := serviceRepo.DeployService(ctx, serviceId)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
 			respJSON, err := json.Marshal(updated)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			return mcp.NewToolResultText(string(respJSON)), nil
+			responseText := "Compute plan updated. A new deploy has been triggered to apply the new instance type. " +
+				"This is a zero-downtime change for stateless services; services with an attached persistent disk " +
+				"briefly go down during the switch.\n\n" +
+				"Updated service: " + string(respJSON) + "\n\n" +
+				"Response from deploying service: " + string(deployResponse.Body)
+
+			return mcp.NewToolResultText(responseText), nil
 		},
 	}
 }
@@ -684,8 +699,8 @@ func updateCronJob(serviceRepo *Repo) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("update_cron_job",
 			mcp.WithDescription("Update the compute plan (instance type) of an existing cron job in your Render account. "+
-				"Changing the plan scales the CPU and memory available to each run. Render applies the change immediately, "+
-				"so a manual deploy is not required. "+
+				"Changing the plan scales the CPU and memory available to each run. This triggers a new deploy to apply "+
+				"the new instance type, so no manual deploy is needed. The new plan takes effect on the cron job's next run. "+
 				"This tool currently only supports changing the plan. For other configuration changes, "+
 				"use the dashboard at: "+config.DashboardURL()+"/create"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
@@ -731,12 +746,24 @@ func updateCronJob(serviceRepo *Repo) server.ServerTool {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
+			// The Render API records the new plan but does not apply it until the next
+			// successful deploy, so trigger one. The new plan takes effect on the next run.
+			deployResponse, err := serviceRepo.DeployService(ctx, serviceId)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
 			respJSON, err := json.Marshal(updated)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			return mcp.NewToolResultText(string(respJSON)), nil
+			responseText := "Compute plan updated. A new deploy has been triggered to apply the new instance type, " +
+				"which takes effect on the cron job's next run.\n\n" +
+				"Updated service: " + string(respJSON) + "\n\n" +
+				"Response from deploying service: " + string(deployResponse.Body)
+
+			return mcp.NewToolResultText(responseText), nil
 		},
 	}
 }

--- a/pkg/service/tools.go
+++ b/pkg/service/tools.go
@@ -23,9 +23,9 @@ func Tools(c *client.ClientWithResponses) []server.ServerTool {
 		createWebService(serviceRepo),
 		createStaticSite(serviceRepo),
 		createCronJob(serviceRepo),
-		updateWebService(),
+		updateWebService(serviceRepo),
 		updateStaticSite(),
-		updateCronJob(),
+		updateCronJob(serviceRepo),
 		updateEnvVars(serviceRepo),
 	}
 }
@@ -111,7 +111,7 @@ func createWebService(serviceRepo *Repo) server.ServerTool {
 			mcp.WithDescription("Create a new web service in your Render account. "+
 				"A web service is a public-facing service that can be accessed by users on the internet. "+
 				"By default, these services are automatically deployed when the specified branch is updated "+
-				"and do not require a manual trigger of a deploy. The user should only be prompted to manually trigger a deploy if auto-deploy is disabled."+
+				"and do not require a manual trigger of a deploy. Only prompt to manually trigger a deploy if auto-deploy is disabled."+
 				"This tool is currently limited to support only a subset of the web service configuration parameters."+
 				"It also only supports web services which don't use Docker, or a container registry."+
 				"To create a service without those limitations, please use the dashboard at: "+config.DashboardURL()+"/web/new"),
@@ -589,20 +589,29 @@ func createValidatedCronJobRequest(ctx context.Context, request mcp.CallToolRequ
 	return validatedCreateServiceRequest(ctx, request, client.CronJob, &serviceDetails)
 }
 
-func updateWebService() server.ServerTool {
+func updateWebService(serviceRepo *Repo) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("update_web_service",
-			mcp.WithDescription("Update an existing web service in your Render account."),
+			mcp.WithDescription("Update the compute plan (instance type) of an existing web service in your Render account. "+
+				"Changing the plan scales the service's CPU and memory. Render applies the change immediately, "+
+				"so a manual deploy is not required. "+
+				"This tool currently only supports changing the plan. For other configuration changes, "+
+				"use the dashboard at: "+config.DashboardURL()+"/web/new"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:           "Update web service",
-				ReadOnlyHint:    pointers.From(true),
+				ReadOnlyHint:    pointers.From(false),
 				DestructiveHint: pointers.From(false),
 				IdempotentHint:  pointers.From(true),
-				OpenWorldHint:   pointers.From(false),
+				OpenWorldHint:   pointers.From(true),
 			}),
 			mcp.WithString("serviceId",
 				mcp.Required(),
-				mcp.Description("The ID of the service to update"),
+				mcp.Description("The ID of the web service to update"),
+			),
+			mcp.WithString("plan",
+				mcp.Required(),
+				mcp.Description("The new pricing plan for your web service. Different plans offer different levels of resources."),
+				mcp.Enum(mcpserver.ServicePlanEnumValues()...),
 			),
 		),
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -611,10 +620,32 @@ func updateWebService() server.ServerTool {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			// Return a message indicating direct updates are not supported via MCP server
-			return mcp.NewToolResultText(
-				"Updating a service directly is not supported. Please make changes using the dashboard or the API.\n\n" +
-					"Dashboard URL: " + config.DashboardURL() + "/web/" + serviceId + "/settings"), nil
+			plan, err := validate.RequiredToolParam[string](request, "plan")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			servicePlan, err := validate.ServicePlan(plan)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			serviceDetails := client.ServicePATCH_ServiceDetails{}
+			if err = serviceDetails.FromWebServiceDetailsPATCH(client.WebServiceDetailsPATCH{Plan: servicePlan}); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			body := client.UpdateServiceJSONRequestBody{ServiceDetails: &serviceDetails}
+			updated, err := serviceRepo.UpdateService(ctx, serviceId, client.WebService, body)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			respJSON, err := json.Marshal(updated)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			return mcp.NewToolResultText(string(respJSON)), nil
 		},
 	}
 }
@@ -649,20 +680,29 @@ func updateStaticSite() server.ServerTool {
 	}
 }
 
-func updateCronJob() server.ServerTool {
+func updateCronJob(serviceRepo *Repo) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("update_cron_job",
-			mcp.WithDescription("Update an existing cron job in your Render account."),
+			mcp.WithDescription("Update the compute plan (instance type) of an existing cron job in your Render account. "+
+				"Changing the plan scales the CPU and memory available to each run. Render applies the change immediately, "+
+				"so a manual deploy is not required. "+
+				"This tool currently only supports changing the plan. For other configuration changes, "+
+				"use the dashboard at: "+config.DashboardURL()+"/create"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:           "Update cron job",
-				ReadOnlyHint:    pointers.From(true),
+				ReadOnlyHint:    pointers.From(false),
 				DestructiveHint: pointers.From(false),
 				IdempotentHint:  pointers.From(true),
-				OpenWorldHint:   pointers.From(false),
+				OpenWorldHint:   pointers.From(true),
 			}),
 			mcp.WithString("serviceId",
 				mcp.Required(),
-				mcp.Description("The ID of the service to update"),
+				mcp.Description("The ID of the cron job to update"),
+			),
+			mcp.WithString("plan",
+				mcp.Required(),
+				mcp.Description("The new pricing plan for your cron job. Different plans offer different levels of resources."),
+				mcp.Enum(mcpserver.ServicePlanEnumValues()...),
 			),
 		),
 		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -671,10 +711,32 @@ func updateCronJob() server.ServerTool {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
-			// Return a message indicating direct updates are not supported via MCP server
-			return mcp.NewToolResultText(
-				"Updating a cron job directly is not supported. Please make changes using the dashboard or the API.\n\n" +
-					"Dashboard URL: " + config.DashboardURL() + "/cron/" + serviceId + "/settings"), nil
+			plan, err := validate.RequiredToolParam[string](request, "plan")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			servicePlan, err := validate.ServicePlan(plan)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			serviceDetails := client.ServicePATCH_ServiceDetails{}
+			if err = serviceDetails.FromCronJobDetailsPATCH(client.CronJobDetailsPATCH{Plan: servicePlan}); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			body := client.UpdateServiceJSONRequestBody{ServiceDetails: &serviceDetails}
+			updated, err := serviceRepo.UpdateService(ctx, serviceId, client.CronJob, body)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			respJSON, err := json.Marshal(updated)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			return mcp.NewToolResultText(string(respJSON)), nil
 		},
 	}
 }

--- a/pkg/service/tools_test.go
+++ b/pkg/service/tools_test.go
@@ -561,3 +561,127 @@ func TestMergeEnvVars(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateWebServiceTool(t *testing.T) {
+	serviceId := "srv-web-123"
+
+	fakeClient := &fakes.FakeServiceRepoClient{}
+	repo := NewRepo(fakeClient)
+
+	fakeClient.RetrieveServiceWithResponseReturns(&client.RetrieveServiceResponse{
+		JSON200:      &client.Service{Id: serviceId, Type: client.WebService},
+		HTTPResponse: &http.Response{StatusCode: 200},
+	}, nil)
+	fakeClient.UpdateServiceWithResponseReturns(&client.UpdateServiceResponse{
+		JSON200:      &client.Service{Id: serviceId, Type: client.WebService},
+		HTTPResponse: &http.Response{StatusCode: 200},
+	}, nil)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"serviceId": serviceId,
+		"plan":      "standard",
+	}
+
+	tool := updateWebService(repo)
+	result, err := tool.Handler(context.Background(), request)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "expected no error but got: %v", result.Content)
+
+	assert.Equal(t, 1, fakeClient.UpdateServiceWithResponseCallCount())
+	_, gotServiceId, body, _ := fakeClient.UpdateServiceWithResponseArgsForCall(0)
+	assert.Equal(t, serviceId, gotServiceId)
+
+	require.NotNil(t, body.ServiceDetails)
+	patch, err := body.ServiceDetails.AsWebServiceDetailsPATCH()
+	require.NoError(t, err)
+	assert.Equal(t, pointers.From(client.PaidPlanStandard), patch.Plan)
+}
+
+func TestUpdateWebServiceToolRejectsWrongServiceType(t *testing.T) {
+	serviceId := "crn-123"
+
+	fakeClient := &fakes.FakeServiceRepoClient{}
+	repo := NewRepo(fakeClient)
+
+	// The service exists but is a cron job, not a web service.
+	fakeClient.RetrieveServiceWithResponseReturns(&client.RetrieveServiceResponse{
+		JSON200:      &client.Service{Id: serviceId, Type: client.CronJob},
+		HTTPResponse: &http.Response{StatusCode: 200},
+	}, nil)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"serviceId": serviceId,
+		"plan":      "standard",
+	}
+
+	tool := updateWebService(repo)
+	result, err := tool.Handler(context.Background(), request)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError, "expected an error result for a service-type mismatch")
+	assert.Equal(t, 0, fakeClient.UpdateServiceWithResponseCallCount())
+}
+
+func TestUpdateWebServiceToolRejectsInvalidPlan(t *testing.T) {
+	fakeClient := &fakes.FakeServiceRepoClient{}
+	repo := NewRepo(fakeClient)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"serviceId": "srv-web-123",
+		"plan":      "not-a-real-plan",
+	}
+
+	tool := updateWebService(repo)
+	result, err := tool.Handler(context.Background(), request)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError, "expected an error result for an invalid plan")
+	// An invalid plan is rejected before any API calls are made.
+	assert.Equal(t, 0, fakeClient.RetrieveServiceWithResponseCallCount())
+	assert.Equal(t, 0, fakeClient.UpdateServiceWithResponseCallCount())
+}
+
+func TestUpdateCronJobTool(t *testing.T) {
+	serviceId := "crn-123"
+
+	fakeClient := &fakes.FakeServiceRepoClient{}
+	repo := NewRepo(fakeClient)
+
+	fakeClient.RetrieveServiceWithResponseReturns(&client.RetrieveServiceResponse{
+		JSON200:      &client.Service{Id: serviceId, Type: client.CronJob},
+		HTTPResponse: &http.Response{StatusCode: 200},
+	}, nil)
+	fakeClient.UpdateServiceWithResponseReturns(&client.UpdateServiceResponse{
+		JSON200:      &client.Service{Id: serviceId, Type: client.CronJob},
+		HTTPResponse: &http.Response{StatusCode: 200},
+	}, nil)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"serviceId": serviceId,
+		"plan":      "starter",
+	}
+
+	tool := updateCronJob(repo)
+	result, err := tool.Handler(context.Background(), request)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "expected no error but got: %v", result.Content)
+
+	assert.Equal(t, 1, fakeClient.UpdateServiceWithResponseCallCount())
+	_, gotServiceId, body, _ := fakeClient.UpdateServiceWithResponseArgsForCall(0)
+	assert.Equal(t, serviceId, gotServiceId)
+
+	require.NotNil(t, body.ServiceDetails)
+	patch, err := body.ServiceDetails.AsCronJobDetailsPATCH()
+	require.NoError(t, err)
+	assert.Equal(t, pointers.From(client.PaidPlanStarter), patch.Plan)
+}

--- a/pkg/service/tools_test.go
+++ b/pkg/service/tools_test.go
@@ -576,6 +576,10 @@ func TestUpdateWebServiceTool(t *testing.T) {
 		JSON200:      &client.Service{Id: serviceId, Type: client.WebService},
 		HTTPResponse: &http.Response{StatusCode: 200},
 	}, nil)
+	fakeClient.CreateDeployWithResponseReturns(&client.CreateDeployResponse{
+		HTTPResponse: &http.Response{StatusCode: 201},
+		Body:         []byte("create deploy response"),
+	}, nil)
 
 	request := mcp.CallToolRequest{}
 	request.Params.Arguments = map[string]any{
@@ -598,6 +602,11 @@ func TestUpdateWebServiceTool(t *testing.T) {
 	patch, err := body.ServiceDetails.AsWebServiceDetailsPATCH()
 	require.NoError(t, err)
 	assert.Equal(t, pointers.From(client.PaidPlanStandard), patch.Plan)
+
+	// A plan change only takes effect on the next deploy, so the tool must trigger one.
+	assert.Equal(t, 1, fakeClient.CreateDeployWithResponseCallCount())
+	_, deployServiceId, _, _ := fakeClient.CreateDeployWithResponseArgsForCall(0)
+	assert.Equal(t, serviceId, deployServiceId)
 }
 
 func TestUpdateWebServiceToolRejectsWrongServiceType(t *testing.T) {
@@ -625,6 +634,7 @@ func TestUpdateWebServiceToolRejectsWrongServiceType(t *testing.T) {
 	require.NotNil(t, result)
 	assert.True(t, result.IsError, "expected an error result for a service-type mismatch")
 	assert.Equal(t, 0, fakeClient.UpdateServiceWithResponseCallCount())
+	assert.Equal(t, 0, fakeClient.CreateDeployWithResponseCallCount())
 }
 
 func TestUpdateWebServiceToolRejectsInvalidPlan(t *testing.T) {
@@ -646,6 +656,7 @@ func TestUpdateWebServiceToolRejectsInvalidPlan(t *testing.T) {
 	// An invalid plan is rejected before any API calls are made.
 	assert.Equal(t, 0, fakeClient.RetrieveServiceWithResponseCallCount())
 	assert.Equal(t, 0, fakeClient.UpdateServiceWithResponseCallCount())
+	assert.Equal(t, 0, fakeClient.CreateDeployWithResponseCallCount())
 }
 
 func TestUpdateCronJobTool(t *testing.T) {
@@ -661,6 +672,10 @@ func TestUpdateCronJobTool(t *testing.T) {
 	fakeClient.UpdateServiceWithResponseReturns(&client.UpdateServiceResponse{
 		JSON200:      &client.Service{Id: serviceId, Type: client.CronJob},
 		HTTPResponse: &http.Response{StatusCode: 200},
+	}, nil)
+	fakeClient.CreateDeployWithResponseReturns(&client.CreateDeployResponse{
+		HTTPResponse: &http.Response{StatusCode: 201},
+		Body:         []byte("create deploy response"),
 	}, nil)
 
 	request := mcp.CallToolRequest{}
@@ -684,4 +699,9 @@ func TestUpdateCronJobTool(t *testing.T) {
 	patch, err := body.ServiceDetails.AsCronJobDetailsPATCH()
 	require.NoError(t, err)
 	assert.Equal(t, pointers.From(client.PaidPlanStarter), patch.Plan)
+
+	// A plan change only takes effect on the next deploy, so the tool must trigger one.
+	assert.Equal(t, 1, fakeClient.CreateDeployWithResponseCallCount())
+	_, deployServiceId, _, _ := fakeClient.CreateDeployWithResponseArgsForCall(0)
+	assert.Equal(t, serviceId, deployServiceId)
 }


### PR DESCRIPTION
## Summary

- Implements `update_web_service` and `update_cron_job` (previously no-op stubs) to change a service's compute plan, mirroring the plan selection already permitted at creation time.
- Adds `Repo.UpdateService`, which verifies workspace ownership and that the service type matches the tool before issuing the PATCH, returning a clean error on mismatch.
- Triggers a deploy after the PATCH to actually apply the new instance type. The Render API records the new plan but does not apply it until the next successful deploy, so the tools trigger one automatically (matching `update_environment_variables`). This is zero-downtime for stateless web services; services with an attached persistent disk briefly go down, and for cron jobs the new plan takes effect on the next run.
- Static sites are intentionally left unchanged (no compute plan).
- Updates the generated `serviceRepoClient` fake and documents the new `plan` parameter in the README.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (new tests cover the happy path including the triggered deploy, service-type mismatch, and invalid-plan rejection)